### PR TITLE
Add methods for modifying reactions locally

### DIFF
--- a/Example/ExampleTests/LikeTest.swift
+++ b/Example/ExampleTests/LikeTest.swift
@@ -115,6 +115,22 @@ class LikeTest: XCTestCase {
         expect(wasLiked).toEventually(beTrue())
     }
 
+    func testSetUserReactionLocally() throws {
+        post.setUserReactionLocally(.wow, true)
+        expect(self.post.hasReacted?[.wow]).toEventually(beTrue())
+    }
+
+    func testIncreaseReactionCountLocally() throws {
+        post.increaseReactionCountLocally(.wow)
+        expect(self.post.reactions?[.wow]).to(equal(1))
+    }
+
+    func testIncreaseReactionCountLocallyTwice() throws {
+        post.increaseReactionCountLocally(.wow)
+        post.increaseReactionCountLocally(.wow)
+        expect(self.post.reactions?[.wow]).to(equal(2))
+    }
+
     func testDeleteLikeReaction() throws {
         var wasDeleted = false
         _ = try tapglue.createReaction(.like, forPostId: post.id!).toBlocking().first()

--- a/Sources/Entities/Post.swift
+++ b/Sources/Entities/Post.swift
@@ -54,6 +54,14 @@ open class Post: Mappable {
         self.visibility = visibility
         self.attachments = attachments
     }
+
+    public func setUserReactionLocally(_ reaction: Reaction, _ value: Bool) {
+        rawOwnReactions?[reaction.rawValue] = value
+    }
+
+    public func increaseReactionCountLocally(_ reaction: Reaction) {
+        rawReactions?[reaction.rawValue] = (rawReactions?[reaction.rawValue] ?? 0) + 1
+    }
     
     required public init?(map: Map) {
         
@@ -74,7 +82,6 @@ open class Post: Mappable {
         likeCount   <- map["counts.likes"]
         commentCount    <- map["counts.comments"]
     }
-    
 }
 
 open class Attachment: Mappable {


### PR DESCRIPTION
Useful for UI optimizations such as increasing the count after a
successful reaction, and for setting the reaction as set on a UI
level. Will not modify the object remotely.